### PR TITLE
github: add talk type (remote or physical)

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-proposal.md
+++ b/.github/ISSUE_TEMPLATE/new-proposal.md
@@ -22,5 +22,9 @@ __language__:
 - [ ] :fr:
 - [ ] :uk:
 
+**this talk will be done**:
+- [ ] remotely
+- [ ] physically
+
 __abstract__:
 <!-- in a few lines, content of your talk -->


### PR DESCRIPTION
since we started to host hybrid meetups, it's always good to know the
expected type of talk.

Signed-off-by: Mathieu Tortuyaux <mathieu.tortuyaux@gmail.com>