### PR TITLE
Support slash and backslash chars on titles

### DIFF
--- a/scripts/create-content/main.py
+++ b/scripts/create-content/main.py
@@ -21,6 +21,7 @@ def slugify(date, title):
     slug = slug.replace("—", "")
     slug = slug.replace("…", "")
     slug = slug.replace("\"", "")
+    slug = slug.replace("/", "")
 
     # Remove leading, trailing and duplicated whitespaces
     slug = " ".join(slug.split())

--- a/scripts/create-content/main.py
+++ b/scripts/create-content/main.py
@@ -22,6 +22,7 @@ def slugify(date, title):
     slug = slug.replace("…", "")
     slug = slug.replace("\"", "")
     slug = slug.replace("/", "")
+    slug = slug.replace("\\", "")
 
     # Remove leading, trailing and duplicated whitespaces
     slug = " ".join(slug.split())

--- a/scripts/create-content/test_main.py
+++ b/scripts/create-content/test_main.py
@@ -57,10 +57,16 @@ class TestSlugyFunction(unittest.TestCase):
         output = slugify(date, title)
         self.assertEqual(expected, output)
 
-
     def test_slash_title(self):
         date = "2020-10-02"
         title = "ignition / butane: take the power back on your provisioning"
+        expected = "cfp/2020-10-02-ignition-butane-take-the-power-back-on-your-provisioning.md"
+        output = slugify(date, title)
+        self.assertEqual(expected, output)
+
+    def test_backslash_title(self):
+        date = "2020-10-02"
+        title = "ignition \ butane: take the power back on your provisioning"
         expected = "cfp/2020-10-02-ignition-butane-take-the-power-back-on-your-provisioning.md"
         output = slugify(date, title)
         self.assertEqual(expected, output)

--- a/scripts/create-content/test_main.py
+++ b/scripts/create-content/test_main.py
@@ -58,6 +58,14 @@ class TestSlugyFunction(unittest.TestCase):
         self.assertEqual(expected, output)
 
 
+    def test_slash_title(self):
+        date = "2020-10-02"
+        title = "ignition / butane: take the power back on your provisioning"
+        expected = "cfp/2020-10-02-ignition-butane-take-the-power-back-on-your-provisioning.md"
+        output = slugify(date, title)
+        self.assertEqual(expected, output)
+
+
 class TestMain(unittest.TestCase):
     @mock.patch("sys.stdout", new_callable=StringIO)
     def test_parse_issue(self, mock_stdout):


### PR DESCRIPTION
As reported on #53 the `content.yaml` workflow brakes with slash and backslash chars on titles.

This PR adds 2 test cases and a fix on slugify to fix the issue.