### PR TITLE
github: add location to template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-proposal.md
+++ b/.github/ISSUE_TEMPLATE/new-proposal.md
@@ -22,9 +22,9 @@ __language__:
 - [ ] :fr:
 - [ ] :uk:
 
-**this talk will be done**:
+**this talk can be done**:
 - [ ] remotely
-- [ ] physically
+- [ ] physically <!-- SRE France meetups are hosted in various locations (Bordeaux, Paris, Lyon, etc.) - please let us now where you'll be available) -->
 
 __abstract__:
 <!-- in a few lines, content of your talk -->


### PR DESCRIPTION
Moving from "SRE Paris" to "SRE France" means that meetups are not
necessarily hosted in Paris.

Signed-off-by: Mathieu Tortuyaux <mathieu.tortuyaux@gmail.com>

<hr>